### PR TITLE
feat: Issue #3 - 이슈 템플릿 추가 (tree-suggestion 자동 레이블)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,31 @@
+name: 🐛 버그 신고 / 일반 피드백
+description: 프론트엔드 오류, 링크 오류, 또는 일반적인 피드백을 남깁니다
+body:
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: 문제 유형
+      options:
+        - 프론트엔드 버그 (화면 오류, 링크 동작 안 함 등)
+        - 트리 내용 오류 (잘못된 정보, 깨진 링크)
+        - 기타 피드백
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 문제 설명
+      placeholder: 어떤 문제가 발생했는지 설명해 주세요.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 재현 방법 (버그인 경우)
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/tree-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/tree-suggestion.yml
@@ -1,0 +1,35 @@
+name: 🌳 트리 노드 제안
+description: 의사결정 트리에 새로운 질문이나 결과 노드를 제안합니다
+labels: ["tree-suggestion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        제안해 주신 내용을 바탕으로 AI가 자동으로 트리를 확장합니다.
+        아래 필드를 최대한 채워주시면 더 정확하게 반영됩니다.
+
+  - type: input
+    id: parent-node
+    attributes:
+      label: 어느 노드 아래에 추가하고 싶으신가요?
+      description: 연결할 기존 노드 ID를 입력하세요 (예: game-type, web-or-app). 모르면 비워두세요.
+      placeholder: "예: game-type"
+    validations:
+      required: false
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: 어떤 내용을 추가하고 싶으신가요?
+      description: 추가할 질문, 선택지, 또는 결과 노드를 자유롭게 설명해 주세요.
+      placeholder: "예: Godot 엔진으로 게임을 만들고 싶어요. game-type 아래에 Godot 선택지를 추가하고, 결과 노드에 Godot 추천 리소스를 넣어주세요."
+    validations:
+      required: true
+
+  - type: input
+    id: target-audience
+    attributes:
+      label: 이 분기는 어떤 사람을 위한 것인가요? (선택)
+      placeholder: "예: 2D 게임 개발에 관심 있는 입문자"
+    validations:
+      required: false


### PR DESCRIPTION
## 개요
Closes #3

## 변경사항
- `.github/ISSUE_TEMPLATE/tree-suggestion.yml`: 트리 노드 제안 템플릿, `tree-suggestion` 레이블 자동 부착
- `.github/ISSUE_TEMPLATE/bug_report.yml`: 버그/일반 피드백 템플릿
- `.github/ISSUE_TEMPLATE/config.yml`: blank issue 허용

## 효과
이제 이슈 생성 버튼을 누르면 템플릿 선택 화면이 표시됩니다.
'트리 노드 제안'을 선택하면 tree-suggestion 레이블이 자동으로 붙어 AI 워크플로우가 트리거됩니다.