### PR TITLE
feat: Issue #5 - UI 트리 레이아웃 및 선택 시 중앙 박스 표시

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,14 @@
 (() => {
   'use strict';
 
+  // [debug:#5] Tree UI rewrite - issue #5
+  console.log('[debug:#5] app.js loaded - tree layout mode');
+
   let tree = null;   // Map<id, {id, title, body, choices}>
   let meta = null;   // {title, description, version, start}
   let history = [];  // stack of visited node IDs
+  let nodePositions = new Map(); // Map<id, {x, y}>
+  let selectedNode = null;
 
   // --- Parser ---
   function parse(raw) {
@@ -41,47 +46,6 @@
     return { meta: fm, nodes };
   }
 
-  // --- Renderer ---
-  function render(nodeId) {
-    const card = document.getElementById('card');
-    const node = tree.get(nodeId);
-
-    if (!node) {
-      showError(`노드 "${nodeId}"를 찾을 수 없습니다.`, true);
-      return;
-    }
-
-    card.classList.add('fade-out');
-    setTimeout(() => {
-      let html = `<h2>${node.title}</h2>`;
-
-      if (node.body) {
-        html += `<div class="body-text">${markdownToHtml(node.body)}</div>`;
-      }
-
-      if (node.choices.length > 0) {
-        html += '<div class="choices">';
-        node.choices.forEach((c, i) => {
-          html += `<button class="choice-btn" data-target="${c.target}">
-            <span class="choice-key">${i + 1}</span> ${c.text}
-          </button>`;
-        });
-        html += '</div>';
-      } else {
-        html += '<button class="restart-btn" id="restart">처음부터 다시 하기</button>';
-      }
-
-      if (history.length > 1) {
-        html += '<button class="back-btn" id="back">← 이전으로 (Esc)</button>';
-      }
-
-      card.innerHTML = html;
-      card.classList.remove('fade-out');
-      renderProgress();
-      bindEvents();
-    }, 300);
-  }
-
   function markdownToHtml(text) {
     return text
       .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
@@ -90,67 +54,291 @@
       .replace(/\n- /g, '<br>• ');
   }
 
-  function renderProgress() {
-    const dots = history.map((_, i) =>
-      `<span class="progress-dot${i === history.length - 1 ? ' active' : ''}"></span>`
-    ).join('');
-    document.getElementById('progress').innerHTML = dots;
+  // --- Tree Layout Calculation ---
+  function buildTreeLayout() {
+    // [debug:#5] calculating tree layout positions
+    console.log('[debug:#5] buildTreeLayout() called');
+
+    const startId = meta.start;
+    const levels = new Map(); // id -> level
+    const visited = new Set();
+    const queue = [[startId, 0]];
+    const levelNodes = {}; // level -> [id]
+    const parentMap = new Map(); // id -> parentId
+
+    while (queue.length > 0) {
+      const [id, level] = queue.shift();
+      if (visited.has(id)) continue;
+      visited.add(id);
+      levels.set(id, level);
+      if (!levelNodes[level]) levelNodes[level] = [];
+      levelNodes[level].push(id);
+
+      const node = tree.get(id);
+      if (node) {
+        for (const choice of node.choices) {
+          if (!visited.has(choice.target)) {
+            queue.push([choice.target, level + 1]);
+            parentMap.set(choice.target, id);
+          }
+        }
+      }
+    }
+
+    const NODE_W = 160;
+    const NODE_H = 60;
+    const H_GAP = 40;
+    const V_GAP = 100;
+    const maxLevel = Math.max(...Object.keys(levelNodes).map(Number));
+
+    nodePositions = new Map();
+    for (let lvl = 0; lvl <= maxLevel; lvl++) {
+      const nodes = levelNodes[lvl] || [];
+      const totalW = nodes.length * NODE_W + (nodes.length - 1) * H_GAP;
+      nodes.forEach((id, i) => {
+        const x = -totalW / 2 + i * (NODE_W + H_GAP) + NODE_W / 2;
+        const y = lvl * (NODE_H + V_GAP);
+        nodePositions.set(id, { x, y, w: NODE_W, h: NODE_H });
+      });
+    }
+
+    console.log('[debug:#5] nodePositions built for', nodePositions.size, 'nodes');
+    return { parentMap, levelNodes };
   }
 
-  function showError(msg, showHome) {
-    const card = document.getElementById('card');
-    card.innerHTML = '';
-    const err = document.getElementById('error');
-    err.hidden = false;
-    let html = `<h2>오류</h2><p>${msg}</p>`;
-    if (showHome) {
-      html += `<br><button class="restart-btn" id="restart">처음으로 돌아가기</button>`;
+  // --- Render Tree ---
+  function renderTree(activeNodeId) {
+    console.log('[debug:#5] renderTree() activeNodeId=', activeNodeId);
+
+    // Remove existing center panel and tree-container
+    const existingPanel = document.getElementById('center-panel');
+    if (existingPanel) existingPanel.remove();
+    const existingContainer = document.getElementById('tree-container');
+    if (existingContainer) existingContainer.remove();
+
+    const wrapper = document.getElementById('tree-wrapper');
+    const { parentMap } = buildTreeLayout();
+
+    // Container
+    const container = document.createElement('div');
+    container.id = 'tree-container';
+
+    // SVG for lines
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.id = 'tree-svg';
+    container.appendChild(svg);
+
+    // Nodes
+    const nodesDiv = document.createElement('div');
+    nodesDiv.id = 'tree-nodes';
+    container.appendChild(nodesDiv);
+
+    wrapper.appendChild(container);
+
+    // Compute bounding box to set offsets
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const [, pos] of nodePositions) {
+      minX = Math.min(minX, pos.x - pos.w / 2);
+      minY = Math.min(minY, pos.y - pos.h / 2);
+      maxX = Math.max(maxX, pos.x + pos.w / 2);
+      maxY = Math.max(maxY, pos.y + pos.h / 2);
     }
-    err.innerHTML = html;
-    const btn = document.getElementById('restart');
-    if (btn) btn.addEventListener('click', () => {
-      err.hidden = true;
-      navigate(meta.start);
+    const padding = 40;
+    const totalW = maxX - minX + padding * 2;
+    const totalH = maxY - minY + padding * 2;
+    const offsetX = -minX + padding;
+    const offsetY = -minY + padding;
+
+    container.style.width = totalW + 'px';
+    container.style.height = totalH + 'px';
+    svg.setAttribute('width', totalW);
+    svg.setAttribute('height', totalH);
+    svg.setAttribute('viewBox', `0 0 ${totalW} ${totalH}`);
+
+    // Draw lines (edges)
+    for (const [childId, parentId] of parentMap) {
+      const cp = nodePositions.get(childId);
+      const pp = nodePositions.get(parentId);
+      if (!cp || !pp) continue;
+
+      const x1 = pp.x + offsetX;
+      const y1 = pp.y + offsetY + pp.h / 2;
+      const x2 = cp.x + offsetX;
+      const y2 = cp.y + offsetY - cp.h / 2;
+
+      const line = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      const mx = (y1 + y2) / 2;
+      line.setAttribute('d', `M ${x1} ${y1} C ${x1} ${mx}, ${x2} ${mx}, ${x2} ${y2}`);
+      line.setAttribute('stroke', 'var(--tree-line)');
+      line.setAttribute('stroke-width', '2');
+      line.setAttribute('fill', 'none');
+      line.setAttribute('class', 'tree-edge');
+
+      // Highlight path to active node
+      if (isInPath(activeNodeId, childId, parentMap) || isInPath(activeNodeId, parentId, parentMap)
+          || childId === activeNodeId || parentId === activeNodeId) {
+        line.classList.add('tree-edge-active');
+      }
+      svg.appendChild(line);
+    }
+
+    // Draw nodes
+    for (const [id, pos] of nodePositions) {
+      const node = tree.get(id);
+      if (!node) continue;
+
+      const div = document.createElement('div');
+      div.className = 'tree-node';
+      div.dataset.id = id;
+      div.style.left = (pos.x + offsetX - pos.w / 2) + 'px';
+      div.style.top = (pos.y + offsetY - pos.h / 2) + 'px';
+      div.style.width = pos.w + 'px';
+      div.style.height = pos.h + 'px';
+
+      const inHistoryIdx = history.indexOf(id);
+      if (id === activeNodeId) {
+        div.classList.add('tree-node-active');
+      } else if (inHistoryIdx >= 0) {
+        div.classList.add('tree-node-visited');
+      }
+
+      // Check if this is a child of active node
+      const activeNode = tree.get(activeNodeId);
+      if (activeNode && activeNode.choices.some(c => c.target === id)) {
+        div.classList.add('tree-node-child');
+      }
+
+      div.innerHTML = `<span class="tree-node-title">${node.title}</span>`;
+      div.addEventListener('click', () => onNodeClick(id));
+      nodesDiv.appendChild(div);
+    }
+
+    // Scroll active node into center
+    scrollToNode(activeNodeId, offsetX, offsetY);
+
+    // Show center modal for active node if it has choices or body
+    showCenterPanel(activeNodeId);
+  }
+
+  function isInPath(targetId, nodeId, parentMap) {
+    let cur = nodeId;
+    const visited = new Set();
+    while (cur && !visited.has(cur)) {
+      if (cur === targetId) return true;
+      visited.add(cur);
+      cur = parentMap.get(cur);
+    }
+    return false;
+  }
+
+  function scrollToNode(nodeId, offsetX, offsetY) {
+    const pos = nodePositions.get(nodeId);
+    if (!pos) return;
+    const absX = pos.x + offsetX;
+    const absY = pos.y + offsetY;
+    const wrapper = document.getElementById('tree-wrapper');
+    if (!wrapper) return;
+    const ww = wrapper.clientWidth;
+    const wh = wrapper.clientHeight;
+    wrapper.scrollLeft = absX - ww / 2;
+    wrapper.scrollTop = absY - wh / 2;
+  }
+
+  // --- Center Panel ---
+  function showCenterPanel(nodeId) {
+    console.log('[debug:#5] showCenterPanel() nodeId=', nodeId);
+    const existing = document.getElementById('center-panel');
+    if (existing) existing.remove();
+
+    const node = tree.get(nodeId);
+    if (!node) return;
+
+    const panel = document.createElement('div');
+    panel.id = 'center-panel';
+    panel.className = 'center-panel-enter';
+
+    let html = `<div class="center-panel-header">
+      <h2>${node.title}</h2>
+      <button class="center-panel-close" id="close-panel" title="닫기">×</button>
+    </div>`;
+
+    if (node.body) {
+      html += `<div class="body-text">${markdownToHtml(node.body)}</div>`;
+    }
+
+    if (node.choices.length > 0) {
+      html += '<div class="choices">';
+      node.choices.forEach((c, i) => {
+        html += `<button class="choice-btn" data-target="${c.target}">
+          <span class="choice-key">${i + 1}</span> ${c.text}
+        </button>`;
+      });
+      html += '</div>';
+    } else {
+      html += '<div class="leaf-message">최종 선택입니다.</div>';
+      html += '<button class="restart-btn" id="restart">처음부터 다시 하기</button>';
+    }
+
+    panel.innerHTML = html;
+    document.getElementById('app').appendChild(panel);
+
+    // Trigger animation
+    requestAnimationFrame(() => {
+      panel.classList.remove('center-panel-enter');
+      panel.classList.add('center-panel-visible');
     });
-  }
 
-  // --- Navigation ---
-  function navigate(nodeId) {
-    document.getElementById('error').hidden = true;
-    if (history[history.length - 1] !== nodeId) history.push(nodeId);
-    window.location.hash = nodeId;
-    render(nodeId);
-  }
-
-  function goBack() {
-    if (history.length > 1) {
-      history.pop();
-      const prev = history[history.length - 1];
-      window.location.hash = prev;
-      render(prev);
-    }
-  }
-
-  function bindEvents() {
-    document.querySelectorAll('.choice-btn').forEach(btn => {
+    // Bind events
+    panel.querySelectorAll('.choice-btn').forEach(btn => {
       btn.addEventListener('click', () => navigate(btn.dataset.target));
+    });
+    const closeBtn = document.getElementById('close-panel');
+    if (closeBtn) closeBtn.addEventListener('click', () => {
+      panel.classList.remove('center-panel-visible');
+      panel.classList.add('center-panel-exit');
+      setTimeout(() => panel.remove(), 300);
     });
     const restart = document.getElementById('restart');
     if (restart) restart.addEventListener('click', () => {
       history = [];
       navigate(meta.start);
     });
-    const back = document.getElementById('back');
-    if (back) back.addEventListener('click', goBack);
+  }
+
+  // --- Navigation ---
+  function onNodeClick(nodeId) {
+    console.log('[debug:#5] onNodeClick()', nodeId);
+    navigate(nodeId);
+  }
+
+  function navigate(nodeId) {
+    console.log('[debug:#5] navigate()', nodeId);
+    document.getElementById('error') && (document.getElementById('error').hidden = true);
+    if (history[history.length - 1] !== nodeId) history.push(nodeId);
+    window.location.hash = nodeId;
+    renderTree(nodeId);
+  }
+
+  function showError(msg) {
+    const app = document.getElementById('app');
+    app.innerHTML = `<div id="error"><h2>오류</h2><p>${msg}</p></div>`;
   }
 
   // --- Keyboard ---
   document.addEventListener('keydown', e => {
     if (!tree) return;
-    if (e.key === 'Escape') { goBack(); return; }
+    if (e.key === 'Escape') {
+      const panel = document.getElementById('center-panel');
+      if (panel) {
+        panel.classList.remove('center-panel-visible');
+        panel.classList.add('center-panel-exit');
+        setTimeout(() => panel.remove(), 300);
+      }
+      return;
+    }
     const num = parseInt(e.key);
     if (num >= 1 && num <= 9) {
-      const btns = document.querySelectorAll('.choice-btn');
+      const btns = document.querySelectorAll('#center-panel .choice-btn');
       if (btns[num - 1]) btns[num - 1].click();
     }
   });
@@ -160,13 +348,20 @@
     const id = window.location.hash.slice(1);
     if (id && tree && tree.has(id) && history[history.length - 1] !== id) {
       history.push(id);
-      render(id);
+      renderTree(id);
     }
   });
 
   // --- Init ---
   async function init() {
     try {
+      // Setup wrapper
+      const app = document.getElementById('app');
+      app.innerHTML = '';
+      const wrapperEl = document.createElement('div');
+      wrapperEl.id = 'tree-wrapper';
+      app.appendChild(wrapperEl);
+
       const res = await fetch('README.md');
       if (!res.ok) throw new Error(`README.md 로드 실패 (${res.status})`);
       const raw = await res.text();
@@ -175,11 +370,14 @@
       meta = parsed.meta;
       document.title = meta.title || '의사결정 트리';
 
+      console.log('[debug:#5] tree loaded, nodes:', tree.size);
+
       const hashId = window.location.hash.slice(1);
       const startId = (hashId && tree.has(hashId)) ? hashId : meta.start;
+
       navigate(startId);
     } catch (err) {
-      showError(`${err.message}<br><br><button class="restart-btn" onclick="location.reload()">다시 시도</button>`, false);
+      showError(`${err.message}<br><br><button class="restart-btn" onclick="location.reload()">다시 시도</button>`);
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -10,6 +10,15 @@
   --btn-hover-fg: #ffffff;
   --border: #e8e8ee;
   --muted: #6b7280;
+  --tree-line: #d1d5db;
+  --tree-line-active: #6c63ff;
+  --node-bg: #f9f9fb;
+  --node-active-bg: #6c63ff;
+  --node-active-fg: #ffffff;
+  --node-visited-bg: #ede9fe;
+  --node-child-bg: #f0fdf4;
+  --node-child-border: #22c55e;
+  --overlay: rgba(0, 0, 0, 0.4);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -21,6 +30,14 @@
     --btn-bg: #2a2a3e;
     --border: #2a2a3e;
     --muted: #9ca3af;
+    --tree-line: #374151;
+    --tree-line-active: #818cf8;
+    --node-bg: #1e1e30;
+    --node-active-bg: #6c63ff;
+    --node-visited-bg: #2d2b55;
+    --node-child-bg: #052e16;
+    --node-child-border: #16a34a;
+    --overlay: rgba(0, 0, 0, 0.6);
   }
 }
 
@@ -30,78 +47,224 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background: var(--bg);
   color: var(--fg);
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  height: 100vh;
+  overflow: hidden;
 }
 
 #app {
+  position: relative;
   width: 100%;
-  max-width: 600px;
-  padding: 1rem;
+  height: 100vh;
+  overflow: hidden;
 }
 
-#progress {
+/* ---- Tree Wrapper (scrollable canvas) ---- */
+#tree-wrapper {
+  position: absolute;
+  inset: 0;
+  overflow: auto;
+  cursor: grab;
+}
+
+#tree-wrapper:active {
+  cursor: grabbing;
+}
+
+#tree-container {
+  position: relative;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+/* ---- SVG lines ---- */
+#tree-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.tree-edge {
+  stroke: var(--tree-line);
+  stroke-width: 2;
+  fill: none;
+  transition: stroke 0.3s;
+}
+
+.tree-edge-active {
+  stroke: var(--tree-line-active);
+  stroke-width: 2.5;
+}
+
+/* ---- Tree Nodes ---- */
+#tree-nodes {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.tree-node {
+  position: absolute;
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1.5rem;
+  align-items: center;
   justify-content: center;
-  flex-wrap: wrap;
+  background: var(--node-bg);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 0 12px;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  text-align: center;
+  user-select: none;
 }
 
-.progress-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--border);
-  transition: background 0.3s;
+.tree-node:hover {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.15);
+  transform: scale(1.04);
+  z-index: 10;
 }
 
-.progress-dot.active {
-  background: var(--accent);
+.tree-node-title {
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.3;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
-#card {
+.tree-node-active {
+  background: var(--node-active-bg);
+  border-color: var(--node-active-bg);
+  color: var(--node-active-fg);
+  box-shadow: 0 4px 16px rgba(108, 99, 255, 0.4);
+  z-index: 5;
+}
+
+.tree-node-visited {
+  background: var(--node-visited-bg);
+  border-color: var(--accent);
+  opacity: 0.85;
+}
+
+.tree-node-child {
+  background: var(--node-child-bg);
+  border-color: var(--node-child-border);
+}
+
+/* ---- Center Panel (modal overlay) ---- */
+#center-panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.85);
+  z-index: 100;
   background: var(--card-bg);
-  border-radius: 16px;
-  box-shadow: var(--card-shadow);
-  padding: 2.5rem 2rem;
-  opacity: 1;
-  transform: translateY(0);
-  transition: opacity 0.3s ease, transform 0.3s ease;
-}
-
-#card.fade-out {
+  border-radius: 20px;
+  box-shadow: 0 8px 48px rgba(0, 0, 0, 0.18);
+  padding: 2rem;
+  width: min(540px, 90vw);
+  max-height: 80vh;
+  overflow-y: auto;
   opacity: 0;
-  transform: translateY(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: auto;
 }
 
-#card h2 {
-  font-size: 1.5rem;
+.center-panel-enter {
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.85);
+}
+
+.center-panel-visible {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.center-panel-exit {
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.9);
+}
+
+.center-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.center-panel-header h2 {
+  font-size: 1.4rem;
   line-height: 1.4;
-  margin-bottom: 1.5rem;
+  flex: 1;
 }
 
-#card .body-text {
+.center-panel-close {
+  background: var(--btn-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--muted);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.center-panel-close:hover {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+/* Dim overlay behind center panel */
+#app::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  z-index: 90;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s;
+}
+
+#app:has(#center-panel.center-panel-visible)::after {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* ---- Choices (inside center panel) ---- */
+.body-text {
   line-height: 1.7;
   color: var(--muted);
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
 }
 
-#card .body-text a {
+.body-text a {
   color: var(--accent);
   text-decoration: none;
 }
 
-#card .body-text a:hover {
+.body-text a:hover {
   text-decoration: underline;
 }
 
 .choices {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .choice-btn {
@@ -109,12 +272,12 @@ body {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  padding: 1rem 1.25rem;
+  padding: 0.875rem 1.25rem;
   background: var(--btn-bg);
   color: var(--fg);
   border: 1px solid var(--border);
   border-radius: 12px;
-  font-size: 1rem;
+  font-size: 0.95rem;
   cursor: pointer;
   text-align: left;
   transition: all 0.2s ease;
@@ -132,12 +295,12 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
   background: var(--card-bg);
   border: 1px solid var(--border);
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   font-weight: 600;
   flex-shrink: 0;
 }
@@ -148,15 +311,21 @@ body {
   color: #fff;
 }
 
+.leaf-message {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
 .restart-btn {
   display: inline-block;
-  margin-top: 1.5rem;
-  padding: 0.75rem 2rem;
+  margin-top: 0.5rem;
+  padding: 0.65rem 1.75rem;
   background: var(--accent);
   color: #fff;
   border: none;
   border-radius: 12px;
-  font-size: 1rem;
+  font-size: 0.95rem;
   cursor: pointer;
   transition: background 0.2s;
 }
@@ -165,24 +334,13 @@ body {
   background: var(--accent-hover);
 }
 
-.back-btn {
-  display: inline-block;
-  margin-top: 1rem;
-  padding: 0.4rem 0;
-  background: none;
-  border: none;
-  color: var(--muted);
-  font-size: 0.875rem;
-  cursor: pointer;
-}
-
-.back-btn:hover {
-  color: var(--fg);
-}
-
+/* ---- Error ---- */
 #error {
   text-align: center;
   padding: 2rem;
+  max-width: 500px;
+  margin: auto;
+  margin-top: 4rem;
 }
 
 #error h2 {
@@ -190,12 +348,24 @@ body {
   color: #ef4444;
 }
 
+/* ---- Scrollbar styling ---- */
+#tree-wrapper::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+#tree-wrapper::-webkit-scrollbar-track {
+  background: transparent;
+}
+#tree-wrapper::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
 @media (max-width: 480px) {
-  #card {
-    padding: 1.5rem 1.25rem;
-    border-radius: 12px;
+  .center-panel-header h2 {
+    font-size: 1.15rem;
   }
-  #card h2 {
-    font-size: 1.25rem;
+  #center-panel {
+    padding: 1.5rem 1.25rem;
   }
 }


### PR DESCRIPTION
## 개요
Closes #5

## 변경사항
- 모든 선택지를 트리 형태로 화면에 배치 (계층적 BFS 레이아웃)
- SVG 곡선(cubic bezier)으로 부모-자식 선택지 간 연결선 표시
- 노드 클릭 시 상세 정보와 선택지가 화면 중앙 패널에 부드럽게 등장
- 활성 노드(보라), 방문 노드(연보라), 자식 노드(초록) 상태 시각화
- ESC 키로 중앙 패널 닫기, 숫자 키로 선택지 선택 유지
- `[debug:#5]` 디버깅 로그 추가